### PR TITLE
Use new transifex client written in Go

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -9,12 +9,12 @@ LABEL org.opencontainers.image.documentation="https://github.com/owncloud-ci/tra
 
 ARG BUILD_VERSION
 
-# renovate: datasource=pypi depName=transifex-client
-ENV TRANSIFEX_VERSION="${BUILD_VERSION:-0.14.4}"
+# renovate: datasource=github-releases depName=transifex/cli
+ENV TRANSIFEX_VERSION="${BUILD_VERSION:-1.6.4}"
 
 RUN apt-get update && \
-    apt-get install -y git-core perl gettext liblocale-po-perl liblocale-gettext-perl python3 python3-pip && \
-    pip3 install -U "transifex-client==$TRANSIFEX_VERSION" && \
+    apt-get install -y git-core perl gettext liblocale-po-perl liblocale-gettext-perl && \
+    curl -SsfL "https://github.com/transifex/cli/releases/download/v${TRANSIFEX_VERSION}/tx-linux-amd64.tar.gz" | tar xz -C /usr/local/bin tx && \
     npm install -g yarn --force && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The old one written in Python is no longer maintained apparently, and also doesn't work reliably any more.